### PR TITLE
Integration of Cosign. Docker images signature in github actions.

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -17,11 +17,14 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'geoserver/geoserver-cloud'
+    if: github.repository == 'jemacchi/geoserver-cloud'
     name: Build and Push
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.5.0
+
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -32,6 +35,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -49,10 +53,34 @@ jobs:
     - name: Build images
       run: |
         make build-image
+      env:
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+
+    - name: Write signing key to disk (only needed for `cosign sign --key`)
+      run: echo "${{ secrets.COSIGN_KEY }}" > cosign.key
 
     - name: Push images
       run: |
         make push-image
+      env:
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+
+    - name: Sign images
+      run: |
+        make sign-image
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+
+    - name: Write pub key to disk (for verification)
+      run: echo "${{ secrets.COSIGN_PUB_KEY }}" > cosign.pub
+
+    - name: Verify images
+      run: |
+        make verify-image
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
     - name: Remove project jars from cached repository
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
     - name: Build docker images
       run: |
         make build-image
+      env:
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
     - name: Remove project jars from cached repository
       run: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -46,6 +46,8 @@ jobs:
     - name: Build images
       run: |
         make build-image
+      env:
+        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
     - name: Remove project jars from cached repository
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 all: install test build-image
 
 TAG=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
+DOCKERHUB_REPO := $(DOCKER_HUB_USERNAME)
+COSIGN_PASSWORD := $(COSIGN_PASSWORD)
 
 clean:
 	./mvnw clean
@@ -17,12 +19,12 @@ install:
 test:
 	./mvnw verify -ntp -T4
 
-
 build-base-images:
 	./mvnw clean package -f src/apps/base-images -DksipTests -T4 && \
 	COMPOSE_DOCKER_CLI_BUILD=1 \
 	DOCKER_BUILDKIT=1 \
 	TAG=$(TAG) \
+	DOCKERHUB_REPO=$(DOCKERHUB_REPO) \
 	docker compose -f docker-build/base-images.yml build 
 
 build-image-infrastructure:
@@ -30,6 +32,7 @@ build-image-infrastructure:
 	COMPOSE_DOCKER_CLI_BUILD=1 \
 	DOCKER_BUILDKIT=1 \
 	TAG=$(TAG) \
+	DOCKERHUB_REPO=$(DOCKERHUB_REPO) \
 	docker compose -f docker-build/infrastructure.yml build
 
 build-image-geoserver:
@@ -37,13 +40,47 @@ build-image-geoserver:
 	COMPOSE_DOCKER_CLI_BUILD=1 \
 	DOCKER_BUILDKIT=1 \
 	TAG=$(TAG) \
+	DOCKERHUB_REPO=$(DOCKERHUB_REPO) \
 	docker compose -f docker-build/geoserver.yml build 
   
 build-image: build-base-images build-image-infrastructure build-image-geoserver
 
 push-image:
 	TAG=$(TAG) \
+	DOCKERHUB_REPO=$(DOCKERHUB_REPO) \
 	docker compose \
 	-f docker-build/infrastructure.yml \
 	-f docker-build/geoserver.yml \
 	push
+
+.PHONY: sign-image
+sign-image:
+	@bash -c '\
+	export COSIGN_PASSWORD=$(COSIGN_PASSWORD); \
+	images=$$(docker images --format "{{.Repository}}@{{.Digest}}" | grep "geoserver-cloud-"); \
+	for image in $$images; do \
+	  echo "Signing $$image"; \
+	  output=$$(cosign sign --yes --key cosign.key $$image 2>&1); \
+	  if [ $$? -ne 0 ]; then \
+	    echo "Error occurred: $$output"; \
+	    exit 1; \
+	  else \
+	    echo "Signing successful: $$output"; \
+	  fi; \
+	done'
+
+.PHONY: verify-image
+verify-image:
+	@bash -c '\
+	images=$$(docker images --format "{{.Repository}}@{{.Digest}}" | grep "geoserver-cloud-"); \
+	for image in $$images; do \
+	  echo "Verifying $$image"; \
+	  output=$$(cosign verify --key cosign.pub $$image 2>&1); \
+	  if [ $$? -ne 0 ]; then \
+	    echo "Error occurred: $$output"; \
+	    exit 1; \
+	  else \
+	    echo "Verification successful: $$output"; \
+	  fi; \
+	done'
+

--- a/docker-build/geoserver.yml
+++ b/docker-build/geoserver.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   wfs:
-    image: geoservercloud/geoserver-cloud-wfs:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-wfs:${TAG}
     build:
       no_cache: true
       pull: false
@@ -11,7 +11,7 @@ services:
         TAG: ${TAG}
 
   wms:
-    image: geoservercloud/geoserver-cloud-wms:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-wms:${TAG}
     build:
       no_cache: true
       pull: false
@@ -20,7 +20,7 @@ services:
         TAG: ${TAG}
 
   wcs:
-    image: geoservercloud/geoserver-cloud-wcs:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-wcs:${TAG}
     build:
       no_cache: true
       pull: false
@@ -29,7 +29,7 @@ services:
         TAG: ${TAG}
 
   wps:
-    image: geoservercloud/geoserver-cloud-wps:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-wps:${TAG}
     build:
       no_cache: true
       pull: false
@@ -38,7 +38,7 @@ services:
         TAG: ${TAG}
 
   rest:
-    image: geoservercloud/geoserver-cloud-rest:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-rest:${TAG}
     build:
       no_cache: true
       pull: false
@@ -47,7 +47,7 @@ services:
         TAG: ${TAG}
 
   webui:
-    image: geoservercloud/geoserver-cloud-webui:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-webui:${TAG}
     build:
       no_cache: true
       pull: false
@@ -56,11 +56,10 @@ services:
         TAG: ${TAG}
 
   gwc:
-    image: geoservercloud/geoserver-cloud-gwc:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-gwc:${TAG}
     build:
       no_cache: true
       pull: false
       context: ../src/apps/geoserver/gwc/
       args:
         TAG: ${TAG}
-    

--- a/docker-build/infrastructure.yml
+++ b/docker-build/infrastructure.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   discovery:
-    image: geoservercloud/geoserver-cloud-discovery:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-discovery:${TAG}
     build:
       no_cache: true
       context: ../src/apps/infrastructure/discovery/
@@ -10,7 +10,7 @@ services:
         TAG: ${TAG}
 
   config:
-    image: geoservercloud/geoserver-cloud-config:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-config:${TAG}
     build:
       no_cache: true
       context: ../src/apps/infrastructure/config/
@@ -18,7 +18,7 @@ services:
         TAG: ${TAG}
 
   admin:
-    image: geoservercloud/geoserver-cloud-admin-server:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-admin-server:${TAG}
     build:
       no_cache: true
       context: ../src/apps/infrastructure/admin/
@@ -26,7 +26,7 @@ services:
         TAG: ${TAG}
     
   gateway:
-    image: geoservercloud/geoserver-cloud-gateway:${TAG}
+    image: ${DOCKERHUB_REPO}/geoserver-cloud-gateway:${TAG}
     build:
       no_cache: true
       context: ../src/apps/infrastructure/gateway/


### PR DESCRIPTION
Required to create these secrets in github actions setup.
![image](https://github.com/jemacchi/geoserver-cloud/assets/1171099/b832872c-c79a-47bb-8c1d-421db53f8c44)

Cosign_key is the private key
Cosign_pub_key the public one (for use in validation process)
Cosign_password is the password for the private key
Docker token and username for dockerhub repo.

You should create your keys with   `cosign generate-key-pair`
You will be challenged for setting a password for the private key (that is going to be the value of your cosign_password secret)
Then you will get 2 files, cosign.key and cosign.pub.

Assign those values to the secrets, and make public the cosign.pub (adding to your repo in git, so people can access it for own validation).

Since cosign advices to avoid signing based on tags, then we are signing images based on digest.
Once pulled in repo, signing procedure is executed and cosign adds a  .sig file into the dockerhub repo, which is used for validation. If the sig file for a digest is removed, then image wont be recognized as signed.

You can validate images in this way:
cosign verify --key cosign.pub jemacchi/geoserver-cloud-wms:1.9-SNAPSHOT

IMPORTANT Note: do not confuse use of Cosign with Docker Content Trust (reference:  https://snyk.io/blog/signing-container-images/ ).
